### PR TITLE
Add support for turbolinks

### DIFF
--- a/app/assets/javascripts/activeadmin-sortable.js
+++ b/app/assets/javascripts/activeadmin-sortable.js
@@ -1,5 +1,5 @@
 (function($) {
-  $(document).ready(function() {
+  $(document).on('ready page:load turbolinks:load', function(){
     $('.handle').closest('tbody').activeAdminSortable();
   });
 


### PR DESCRIPTION
I have a project which include activeadmin and turbolinks. I noticed that the activeadmin-sortable initializer was not called and then I made a little change in order to fix it.