### PR TITLE
Support of descending order and paging

### DIFF
--- a/app/assets/javascripts/activeadmin-sortable.js
+++ b/app/assets/javascripts/activeadmin-sortable.js
@@ -6,12 +6,22 @@
   $.fn.activeAdminSortable = function() {
     this.sortable({
       update: function(event, ui) {
-        var url = ui.item.find('[data-sort-url]').data('sort-url');
+        var elem = ui.item.find('[data-sort-url]'),
+          url = elem.data('sort-url'),
+          fromPos = elem.data('position'),
+          order = elem.data('order') || 'asc',
+          toPos;
+
+        // Find the new position of the moved element through the new position of the kicked out element.
+        toPos = ui.item.next().find('[data-position]').data('position');
+        if (toPos === undefined || (order == 'asc' && toPos > fromPos) || (order == 'desc' && toPos < fromPos)) {
+          toPos = ui.item.prev().find('[data-position]').data('position');
+        }
 
         $.ajax({
           url: url,
           type: 'post',
-          data: { position: ui.item.index() + 1 },
+          data: { position: toPos },
           success: function() { window.location.reload() }
         });
       }

--- a/lib/activeadmin-sortable.rb
+++ b/lib/activeadmin-sortable.rb
@@ -26,7 +26,14 @@ module ActiveAdmin
           sort_url, query_params = resource_path(resource).split '?', 2
           sort_url += "/sort"
           sort_url += "?" + query_params if query_params
-          content_tag :span, HANDLE, :class => 'handle', 'data-sort-url' => sort_url
+          order_by, order_dir = params[:order].split '_', 2
+          position = resource.send(order_by.to_sym)
+          content_tag :span,
+                      HANDLE,
+                      :class => 'handle',
+                      'data-sort-url' => sort_url,
+                      'data-position' => position,
+                      'data-order' => order_dir
         end
       end
     end


### PR DESCRIPTION
On frequent occasions we want to have a descending ordered list in ActiveAdmin. E. g. while managing blog posts, we'd like the recent records appear on the top of the list like they appear in blog. To achieve this behavior, we need to rely on the model's column value rather than DOM index while reordering. Also, this will allow to enable pagination with reordering _within_ a page.  