### PR TITLE
Maintain row width while sorting

### DIFF
--- a/app/assets/javascripts/activeadmin-sortable.js
+++ b/app/assets/javascripts/activeadmin-sortable.js
@@ -3,8 +3,21 @@
     $('.handle').closest('tbody').activeAdminSortable();
   });
 
+  function sortHelper(e, tr)
+  {
+    var $originals = tr.children();
+    var $helper = tr.clone();
+    $helper.children().each(function(index)
+    {
+      // Set helper cell sizes to match the original sizes
+      $(this).outerWidth($originals.eq(index).outerWidth());
+    });
+    return $helper;
+  }
+
   $.fn.activeAdminSortable = function() {
     this.sortable({
+      helper: sortHelper,
       update: function(event, ui) {
         var elem = ui.item.find('[data-sort-url]'),
           url = elem.data('sort-url'),


### PR DESCRIPTION
Adds a helper function that clones the tr and sets the outer widths of each column to their width in the table so that the row maintains its width while being dragged.

This solution is derived from https://stackoverflow.com/questions/1307705/jquery-ui-sortable-with-table-and-tr-width/1372954#1372954